### PR TITLE
Fixed image data size calculations

### DIFF
--- a/Walnut/src/Walnut/Image.cpp
+++ b/Walnut/src/Walnut/Image.cpp
@@ -25,12 +25,12 @@ namespace Walnut {
 			return 0xffffffff;
 		}
 
-		static uint32_t BytesPerChannel(ImageFormat format)
+		static uint32_t BytesPerPixel(ImageFormat format)
 		{
 			switch (format)
 			{
 				case ImageFormat::RGBA:    return 4;
-				case ImageFormat::RGBA32F: return 32;
+				case ImageFormat::RGBA32F: return 16;
 			}
 			return 0;
 		}
@@ -52,32 +52,29 @@ namespace Walnut {
 	{
 		int width, height, channels;
 		uint8_t* data = nullptr;
-		uint64_t size = 0;
 
 		if (stbi_is_hdr(m_Filepath.c_str()))
 		{
 			data = (uint8_t*)stbi_loadf(m_Filepath.c_str(), &width, &height, &channels, 4);
-			size = width * height * 4 * sizeof(float);
 			m_Format = ImageFormat::RGBA32F;
 		}
 		else
 		{
 			data = stbi_load(m_Filepath.c_str(), &width, &height, &channels, 4);
-			size = width * height * 4;
 			m_Format = ImageFormat::RGBA;
 		}
 
 		m_Width = width;
 		m_Height = height;
-
-		AllocateMemory(size);
+		
+		AllocateMemory(m_Width * m_Height * Utils::BytesPerPixel(m_Format));
 		SetData(data);
 	}
 
 	Image::Image(uint32_t width, uint32_t height, ImageFormat format, const void* data)
 		: m_Width(width), m_Height(height), m_Format(format)
 	{
-		AllocateMemory(m_Width * m_Height * Utils::BytesPerChannel(m_Format));
+		AllocateMemory(m_Width * m_Height * Utils::BytesPerPixel(m_Format));
 		if (data)
 			SetData(data);
 	}
@@ -175,7 +172,7 @@ namespace Walnut {
 	{
 		VkDevice device = Application::GetDevice();
 
-		size_t upload_size = m_Width * m_Height * Utils::BytesPerChannel(m_Format);
+		size_t upload_size = m_Width * m_Height * Utils::BytesPerPixel(m_Format);
 
 		VkResult err;
 


### PR DESCRIPTION
I noticed that the texture allocation for floating point textures was twice the size it should be.  The problem was the calculation in BytesPerChannel.  This PR fixes that and renames the function BytesPerPixel since that is how it is being used.

(p.s. the setup for Walnut was sublimely easy, great job)