### PR TITLE
Add support for Linux builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Walnut is a simple application framework built with Dear ImGui and designed to be used with Vulkan - basically this means you can seemlessly blend real-time Vulkan rendering with a great UI library to build desktop applications. The plan is to expand Walnut to include common utilities to make immediate-mode desktop apps and simple Vulkan applications.
 
-Currently supports Windows - with macOS and Linux support planned. Setup scripts support Visual Studio 2022 by default.
+Currently supports Windows and Linux - with macOS support planned. Setup scripts support Visual Studio 2022 by default.
 
 ![WalnutExample](https://hazelengine.com/images/ForestLauncherScreenshot.jpg)
 _<center>Forest Launcher - an application made with Walnut</center>_

--- a/Walnut/src/Walnut/EntryPoint.h
+++ b/Walnut/src/Walnut/EntryPoint.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#ifdef WL_PLATFORM_WINDOWS
-
 extern Walnut::Application* Walnut::CreateApplication(int argc, char** argv);
 bool g_ApplicationRunning = true;
 
@@ -38,5 +36,3 @@ int main(int argc, char** argv)
 }
 
 #endif // WL_DIST
-
-#endif // WL_PLATFORM_WINDOWS

--- a/WalnutApp/premake5.lua
+++ b/WalnutApp/premake5.lua
@@ -22,6 +22,14 @@ project "WalnutApp"
     {
         "Walnut"
     }
+    if string.find(_ACTION, "gmake") then
+       -- Premake5 is about to generate gmake or gmake2 build Makefiles, and
+       -- Makefile support is still new and it does not generate "links" for
+       -- the dependencies needed by Walnut. Add the Linux libs in this case:
+       if os.istarget("linux") then
+          links { "imgui", "glfw", "vulkan" }
+       end
+    end
 
    targetdir ("../bin/" .. outputdir .. "/%{prj.name}")
    objdir ("../bin-int/" .. outputdir .. "/%{prj.name}")

--- a/WalnutExternal.lua
+++ b/WalnutExternal.lua
@@ -12,9 +12,43 @@ LibraryDir["VulkanSDK"] = "%{VULKAN_SDK}/Lib"
 Library = {}
 Library["Vulkan"] = "%{LibraryDir.VulkanSDK}/vulkan-1.lib"
 
+
+function linux_dpkg_check_if_package_is_installed(package)
+   if os.isfile("/usr/bin/dpkg-query") then -- It's Debian or a derivative of it:
+      local result, errorCode = os.outputof("/usr/bin/dpkg-query -Wf'${Status}' " .. package)
+      if errorCode ~= 0 or result ~= "install ok installed" then
+         premake.error("Install " .. package .. " using: sudo apt-get install " .. package)
+      end
+      premake.info(package .. " is installed")
+   else -- Not a Debian-based Linux distro, for now just give a hint:
+      premake.warn("Info: Please be sure that a package like " .. package .. " is installed")
+    end
+end
+
+
 group "Dependencies"
    include "vendor/imgui"
-   include "vendor/glfw"
+   -- When build host and build target are Linux, see if we can check for needed libs:
+   if os.ishost("linux") and os.istarget("linux") then
+      linux_dpkg_check_if_package_is_installed("libglfw3-dev")
+      linux_dpkg_check_if_package_is_installed("libvulkan-dev")
+      linux_dpkg_check_if_package_is_installed("mesa-vulkan-drivers")
+      linux_dpkg_check_if_package_is_installed("vulkan-tools")
+      vulkaninfo_dir = os.pathsearch("vulkaninfo", os.getenv("PATH"))
+      if not vulkaninfo_dir then
+         premake.warn("vulkaninfo not found. Be sure that Vulkan works.")
+      else
+         vulkaninfo = vulkaninfo_dir .. "/vulkaninfo"
+         local result, errorCode = os.outputof(vulkaninfo)
+         if errorCode ~= 0 or string.find(result, "ERROR") then
+               premake.error(vulkaninfo .. " reported an ERROR, please check")
+         end
+         premake.info(vulkaninfo .. " did not show an error, good.")
+      end
+   else
+      -- For other operating systems, build GLFW in the cloned git submodule:
+      include "vendor/GLFW"
+   end
 group ""
 
 group "Core"

--- a/scripts/Setup.bat
+++ b/scripts/Setup.bat
@@ -1,3 +1,4 @@
+#!/usr/bin/echo Download https://premake.github.io and run: "premake5 gmake2 && make". Best regards, 
 @echo off
 
 pushd ..


### PR DESCRIPTION
BTW: On adding trailing newlines to the edited files:

On Linux, common editors like Vim automatically add terminating newlines at the end of files.

PS: Just for your information, with the comitted change to Setup.bat, on Linux, it prints this:

```rb
scripts/Setup.bat
Download https://premake.github.io for Linux and run it. Best regards, scripts/Setup.bat
```