### PR TITLE
Fixed compiler errors when building for C++20.

### DIFF
--- a/Walnut/src/Walnut/Timer.h
+++ b/Walnut/src/Walnut/Timer.h
@@ -14,17 +14,17 @@ namespace Walnut {
 			Reset();
 		}
 
-		void Timer::Reset()
+		void Reset()
 		{
 			m_Start = std::chrono::high_resolution_clock::now();
 		}
 
-		float Timer::Elapsed()
+		float Elapsed()
 		{
 			return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - m_Start).count() * 0.001f * 0.001f * 0.001f;
 		}
 
-		float Timer::ElapsedMillis()
+		float ElapsedMillis()
 		{
 			return Elapsed() * 1000.0f;
 		}


### PR DESCRIPTION
-error C4596: 'Reset': illegal qualified name in member declaration
-error C4596: 'Elapsed': illegal qualified name in member declaration
-error C4596: 'ElapsedMillis': illegal qualified name in member declaration