### PR TITLE
Compatibility with case-sensitive systems

### DIFF
--- a/WalnutExternal.lua
+++ b/WalnutExternal.lua
@@ -14,7 +14,7 @@ Library["Vulkan"] = "%{LibraryDir.VulkanSDK}/vulkan-1.lib"
 
 group "Dependencies"
    include "vendor/imgui"
-   include "vendor/glfw"
+   include "vendor/GLFW"
 group ""
 
 group "Core"


### PR DESCRIPTION
change the names of dependencies so it works on systems other than windows