### PR TITLE
Add basic Linux+CMake support!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vs/
 bin/
 bin-int/
+*build*/
 
 # Files
 *.vcxproj

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,15 +2,14 @@ cmake_minimum_required (VERSION 3.13)
 
 project(Walnut)
 
-if(NOT DEFINED Vulkan_DIR)
-	message(ERROR "Please provide a valid path to the VulkanSDK")
-endif()
-
 set(CMAKE_PREFIX_PATH ${Vulkan_DIR})
 find_package(Vulkan REQUIRED)
 
 # TODO: Figure out how to allow later standards
-set(CMAKE_CXX_STANDARD 17)
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+	set(CMAKE_CXX_STANDARD 17)
+endif()
 
-# add_subdirectory(Walnut)
+add_subdirectory(vendor)
+add_subdirectory(Walnut)
 add_subdirectory(WalnutApp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required (VERSION 3.13)
+
+project(Walnut)
+
+if(NOT DEFINED Vulkan_DIR)
+	message(ERROR "Please provide a valid path to the VulkanSDK")
+endif()
+
+set(CMAKE_PREFIX_PATH ${Vulkan_DIR})
+find_package(Vulkan REQUIRED)
+
+# TODO: Figure out how to allow later standards
+set(CMAKE_CXX_STANDARD 17)
+
+# add_subdirectory(Walnut)
+add_subdirectory(WalnutApp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required (VERSION 3.13)
 
 project(Walnut)
 
-set(CMAKE_PREFIX_PATH ${Vulkan_DIR})
 find_package(Vulkan REQUIRED)
 
 # TODO: Figure out how to allow later standards

--- a/Walnut/CMakeLists.txt
+++ b/Walnut/CMakeLists.txt
@@ -2,7 +2,20 @@ file(GLOB_RECURSE Walnut_SRC LIST_DIRECTORIES false src/*.cpp)
 
 add_library(Walnut STATIC ${Walnut_SRC})
 target_include_directories(Walnut PUBLIC src)
-set_property(TARGET Walnut PROPERTY POSITION_INDEPENDENT_CODE ON)
+# set_property(TARGET Walnut PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+# setup internal project compile definition
+if(WIN32)
+    target_compile_definitions(Walnut PRIVATE WL_PLATFORM_WINDOWS)
+endif()
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_definitions(Walnut PRIVATE WL_DEBUG)
+elseif(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+    target_compile_definitions(Walnut PRIVATE WL_RELEASE)
+elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
+    target_compile_definitions(Walnut PRIVATE WL_DIST)
+endif()
 
 target_link_libraries(Walnut PUBLIC imgui glfw glm::glm stb_image vulkan)
 

--- a/Walnut/CMakeLists.txt
+++ b/Walnut/CMakeLists.txt
@@ -17,6 +17,6 @@ elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
     target_compile_definitions(Walnut PRIVATE WL_DIST)
 endif()
 
-target_link_libraries(Walnut PUBLIC imgui glfw glm::glm stb_image vulkan)
+target_link_libraries(Walnut PUBLIC imgui glfw glm::glm stb_image Vulkan::Vulkan)
 
 install(TARGETS Walnut DESTINATION bin)

--- a/Walnut/CMakeLists.txt
+++ b/Walnut/CMakeLists.txt
@@ -1,0 +1,9 @@
+file(GLOB_RECURSE Walnut_SRC LIST_DIRECTORIES false src/*.cpp)
+
+add_library(Walnut STATIC ${Walnut_SRC})
+target_include_directories(Walnut PUBLIC src)
+set_property(TARGET Walnut PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+target_link_libraries(Walnut PUBLIC imgui glfw glm::glm stb_image vulkan)
+
+install(TARGETS Walnut DESTINATION bin)

--- a/Walnut/CMakeLists.txt
+++ b/Walnut/CMakeLists.txt
@@ -18,5 +18,8 @@ elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
 endif()
 
 target_link_libraries(Walnut PUBLIC imgui glfw glm::glm stb_image Vulkan::Vulkan)
+if(WIN32)
+    target_link_libraries(Walnut PUBLIC dwmapi)
+endif()
 
 install(TARGETS Walnut DESTINATION bin)

--- a/Walnut/src/Walnut/EntryPoint.h
+++ b/Walnut/src/Walnut/EntryPoint.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#ifdef WL_PLATFORM_WINDOWS
-
 extern Walnut::Application* Walnut::CreateApplication(int argc, char** argv);
 bool g_ApplicationRunning = true;
 
@@ -21,7 +19,7 @@ namespace Walnut {
 
 }
 
-#ifdef WL_DIST
+#if defined(WL_DIST) && defined(WL_PLATFORM_WINDOWS)
 
 #include <Windows.h>
 
@@ -37,6 +35,4 @@ int main(int argc, char** argv)
 	return Walnut::Main(argc, argv);
 }
 
-#endif // WL_DIST
-
-#endif // WL_PLATFORM_WINDOWS
+#endif // WL_DIST && WL_PLATFORM_WINDOWS

--- a/WalnutApp/CMakeLists.txt
+++ b/WalnutApp/CMakeLists.txt
@@ -1,0 +1,6 @@
+file(GLOB_RECURSE WalnutApp_SRC LIST_DIRECTORIES false src/*.cpp)
+
+add_executable(WalnutApp ${WalnutApp_SRC})
+target_include_directories(WalnutApp PRIVATE src)
+
+install(WalnutApp DESTINATION bin)

--- a/WalnutApp/CMakeLists.txt
+++ b/WalnutApp/CMakeLists.txt
@@ -2,5 +2,6 @@ file(GLOB_RECURSE WalnutApp_SRC LIST_DIRECTORIES false src/*.cpp)
 
 add_executable(WalnutApp ${WalnutApp_SRC})
 target_include_directories(WalnutApp PRIVATE src)
+target_link_libraries(WalnutApp PRIVATE Walnut)
 
-install(WalnutApp DESTINATION bin)
+install(TARGETS WalnutApp DESTINATION bin)

--- a/WalnutApp/CMakeLists.txt
+++ b/WalnutApp/CMakeLists.txt
@@ -4,4 +4,17 @@ add_executable(WalnutApp ${WalnutApp_SRC})
 target_include_directories(WalnutApp PRIVATE src)
 target_link_libraries(WalnutApp PRIVATE Walnut)
 
+# setup internal project compile definition
+if(WIN32)
+    target_compile_definitions(Walnut PRIVATE WL_PLATFORM_WINDOWS)
+endif()
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_definitions(WalnutApp PRIVATE WL_DEBUG)
+elseif(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+    target_compile_definitions(WalnutApp PRIVATE WL_RELEASE)
+elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
+    target_compile_definitions(WalnutApp PRIVATE WL_DIST)
+endif()
+
 install(TARGETS WalnutApp DESTINATION bin)

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Setup vendor libraries
+## IMGUI (No CMake support, we have to roll or own)
+set(imgui_SRC imgui/imgui.cpp imgui/imgui_draw.cpp imgui/imgui_tables.cpp imgui/imgui_widgets.cpp imgui/imgui_demo.cpp)
+add_library(imgui STATIC ${imgui_SRC})
+target_include_directories(imgui PUBLIC imgui)
+set_property(TARGET imgui PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+## GLFW (comes with its own CMakeLists, let's use that)
+add_subdirectory(GLFW)
+
+## glm (comes with its own CMakeLists, let's use that)
+add_subdirectory(glm)
+
+## stb_image (header-only, create a dummy interface library)
+add_library(stb_image INTERFACE)
+target_include_directories(stb_image INTERFACE stb_image)


### PR DESCRIPTION
This PR adds support for building Walnut under Linux using CMake. 
The build configuration follows very closely the premake one.

On the Walnut side the only thing missing was an entrypoint. The remaining 90% of the work was just writing the CMake build files, basically translating the premake build :)

Tested under Arch Linux, with Vulkan SDK version 1.3.224, CMake 3.24.2
![Screenshot_20221029_171658](https://user-images.githubusercontent.com/10223306/198839868-d016a53f-b5f4-4fa4-87ad-b8d5445683a9.png)

NOTE: this patch also requires a fix in the GLFW submodule, see [corresponding PR in the GLFW repo](https://github.com/TheCherno/glfw/pull/17) 