### PR TITLE
Make random number generation thread local

### DIFF
--- a/Walnut/src/Walnut/Random.cpp
+++ b/Walnut/src/Walnut/Random.cpp
@@ -2,7 +2,7 @@
 
 namespace Walnut {
 
-	std::mt19937 Random::s_RandomEngine;
-	std::uniform_int_distribution<std::mt19937::result_type> Random::s_Distribution;
+	thread_local std::mt19937 Random::s_RandomEngine;
+	thread_local std::uniform_int_distribution<std::mt19937::result_type> Random::s_Distribution;
 
 }

--- a/Walnut/src/Walnut/Random.h
+++ b/Walnut/src/Walnut/Random.h
@@ -44,8 +44,8 @@ namespace Walnut {
 			return glm::normalize(Vec3(-1.0f, 1.0f));
 		}
 	private:
-		static std::mt19937 s_RandomEngine;
-		static std::uniform_int_distribution<std::mt19937::result_type> s_Distribution;
+		thread_local static std::mt19937 s_RandomEngine;
+		thread_local static std::uniform_int_distribution<std::mt19937::result_type> s_Distribution;
 	};
 
 }


### PR DESCRIPTION
Simply makes the random number generation thread local, which massively improves performance when generating random numbers across many threads.