### PR TITLE
Added Support for 32 Bit Apllication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ bin-int/
 
 # Exclude
 !vendor/bin
+imgui.ini

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vs/
 bin/
 bin-int/
+obj/
 
 # Files
 *.vcxproj

--- a/Build-Walnut-ExampleProject.lua
+++ b/Build-Walnut-ExampleProject.lua
@@ -1,8 +1,15 @@
 -- premake5.lua
 workspace "WalnutApp"
-   architecture "x64"
    configurations { "Debug", "Release", "Dist" }
+   platforms { "x32", "x64" }
    startproject "WalnutApp"
+
+   filter "platforms:x32"
+      architecture "x32"
+      defines { "ImTextureID=ImU64" }
+
+   filter "platforms:x64"
+      architecture "x64"
 
    -- Workspace-wide build options for MSVC
    filter "system:windows"

--- a/Build-Walnut-External.lua
+++ b/Build-Walnut-External.lua
@@ -8,10 +8,12 @@ IncludeDir["glm"] = "../vendor/glm"
 IncludeDir["spdlog"] = "../vendor/spdlog/include"
 
 LibraryDir = {}
-LibraryDir["VulkanSDK"] = "%{VULKAN_SDK}/Lib"
+LibraryDir["VulkanSDK32"] = "%{VULKAN_SDK}/Lib32"
+LibraryDir["VulkanSDK64"] = "%{VULKAN_SDK}/Lib"
 
 Library = {}
-Library["Vulkan"] = "%{LibraryDir.VulkanSDK}/vulkan-1.lib"
+Library["Vulkan32"] = "%{LibraryDir.VulkanSDK32}/vulkan-1.lib"
+Library["Vulkan64"] = "%{LibraryDir.VulkanSDK64}/vulkan-1.lib"
 
 group "Dependencies"
    include "vendor/imgui"

--- a/Walnut/Build-Walnut.lua
+++ b/Walnut/Build-Walnut.lua
@@ -32,9 +32,12 @@ project "Walnut"
    {
        "ImGui",
        "GLFW",
-
-       "%{Library.Vulkan}",
    }
+
+   filter "platforms:x32"
+      links "%{Library.Vulkan32}"
+   filter "platforms:x64"
+      links "%{Library.Vulkan64}"
 
    targetdir ("../../bin/" .. outputdir .. "/%{prj.name}")
    objdir ("../../bin-int/" .. outputdir .. "/%{prj.name}")

--- a/Walnut/Platform/GUI/Walnut/Image.cpp
+++ b/Walnut/Platform/GUI/Walnut/Image.cpp
@@ -173,12 +173,12 @@ namespace Walnut {
 			vkFreeMemory(device, stagingBufferMemory, nullptr);
 		});
 
-		m_Sampler = nullptr;
-		m_ImageView = nullptr;
-		m_Image = nullptr;
-		m_Memory = nullptr;
-		m_StagingBuffer = nullptr;
-		m_StagingBufferMemory = nullptr;
+		m_Sampler = 0;
+		m_ImageView = 0;
+		m_Image = 0;
+		m_Memory = 0;
+		m_StagingBuffer = 0;
+		m_StagingBufferMemory = 0;
 	}
 
 	void Image::SetData(const void* data)

--- a/Walnut/Platform/GUI/Walnut/Image.h
+++ b/Walnut/Platform/GUI/Walnut/Image.h
@@ -36,19 +36,19 @@ namespace Walnut {
 	private:
 		uint32_t m_Width = 0, m_Height = 0;
 
-		VkImage m_Image = nullptr;
-		VkImageView m_ImageView = nullptr;
-		VkDeviceMemory m_Memory = nullptr;
-		VkSampler m_Sampler = nullptr;
+		VkImage m_Image = 0;
+		VkImageView m_ImageView = 0;
+		VkDeviceMemory m_Memory = 0;
+		VkSampler m_Sampler = 0;
 
 		ImageFormat m_Format = ImageFormat::None;
 
-		VkBuffer m_StagingBuffer = nullptr;
-		VkDeviceMemory m_StagingBufferMemory = nullptr;
+		VkBuffer m_StagingBuffer = 0;
+		VkDeviceMemory m_StagingBufferMemory = 0;
 
 		size_t m_AlignedSize = 0;
 
-		VkDescriptorSet m_DescriptorSet = nullptr;
+		VkDescriptorSet m_DescriptorSet = 0;
 
 		std::string m_Filepath;
 	};

--- a/WalnutApp/Build-Walnut-App.lua
+++ b/WalnutApp/Build-Walnut-App.lua
@@ -19,10 +19,10 @@ project "WalnutApp"
       "%{IncludeDir.glm}",
    }
 
-    links
-    {
-        "Walnut"
-    }
+   links
+   {
+      "Walnut"
+   }
 
    targetdir ("../bin/" .. outputdir .. "/%{prj.name}")
    objdir ("../bin-int/" .. outputdir .. "/%{prj.name}")


### PR DESCRIPTION
Well as the title says: I added support to run the Application on 32 Bit Systems.
Its only tested on Windows 11 but I doubt this will cause a problem on Windows 10.

Why 32 Bit? Because my project currently supports 32 and 64 bit. I wanted to change to ImGui long time ago and finally got time for it and Walnut was the perfect opportunity. I hope this might help some people.

Adittionally it extends the .gitignore to exclude build files and the imgui.ini