### PR TITLE
Add Support for custom Key Callbacks in Input class

### DIFF
--- a/Walnut/src/Walnut/Input/Input.cpp
+++ b/Walnut/src/Walnut/Input/Input.cpp
@@ -6,13 +6,13 @@
 
 namespace Walnut {
 
+	std::unordered_map<int, std::function<void()>> Input::KEY_CALLBACK_MAP;
+
 	void KeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods)
 	{
 		if (action == GLFW_PRESS)
 		{
-			KeyCode keycode = (KeyCode)key;
-
-			auto funcIter = Input::KEY_CALLBACK_MAP.find(keycode);
+			auto funcIter = Input::KEY_CALLBACK_MAP.find(key);
 			if (funcIter != Input::KEY_CALLBACK_MAP.end())
 			{
 				funcIter->second();
@@ -30,7 +30,7 @@ namespace Walnut {
 
 	void Input::SetKeyCallback(KeyCode keycode, std::function<void()> func)
 	{
-		KEY_CALLBACK_MAP[keycode] = func;
+		KEY_CALLBACK_MAP[(int)keycode] = func;
 	}
 
 	bool Input::IsKeyDown(KeyCode keycode)

--- a/Walnut/src/Walnut/Input/Input.cpp
+++ b/Walnut/src/Walnut/Input/Input.cpp
@@ -6,18 +6,36 @@
 
 namespace Walnut {
 
+	void Input::InitKeysCallBack()
+	{
+		GLFWwindow* windowHandle = Application::Get().GetWindowHandle();
+		glfwSetKeyCallback(windowHandle, KeyCallback);
+	}
+
+	void Input::KeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods)
+	{
+		if (action == GLFW_PRESS)
+		{
+			KeyCode keycode = (KeyCode)key;
+
+			auto funcIter = KEY_CALLBACK_MAP.find(keycode);
+			if (funcIter != KEY_CALLBACK_MAP.end())
+			{
+				funcIter->second();
+			}
+		}
+	}
+
+	void Input::SetKeyCallback(KeyCode keycode, std::function<void()>& func)
+	{
+		KEY_CALLBACK_MAP[keycode] = func;
+	}
+
 	bool Input::IsKeyDown(KeyCode keycode)
 	{
 		GLFWwindow* windowHandle = Application::Get().GetWindowHandle();
 		int state = glfwGetKey(windowHandle, (int)keycode);
 		return state == GLFW_PRESS || state == GLFW_REPEAT;
-	}
-
-	bool Input::IsKeyPressed(KeyCode keycode)
-	{
-		GLFWwindow* windowHandle = Application::Get().GetWindowHandle();
-		int state = glfwGetKey(windowHandle, (int)keycode);
-		return state == GLFW_PRESS;
 	}
 
 	bool Input::IsMouseButtonDown(MouseButton button)

--- a/Walnut/src/Walnut/Input/Input.cpp
+++ b/Walnut/src/Walnut/Input/Input.cpp
@@ -6,14 +6,14 @@
 
 namespace Walnut {
 
-	std::unordered_map<int, std::function<void()>> Input::KEY_CALLBACK_MAP;
+	std::unordered_map<int, std::function<void()>> Input::s_KeyCallbackMap;
 
 	void KeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods)
 	{
 		if (action == GLFW_PRESS || action == GLFW_REPEAT)
 		{
-			auto funcIter = Input::KEY_CALLBACK_MAP.find(key);
-			if (funcIter != Input::KEY_CALLBACK_MAP.end())
+			auto funcIter = Input::s_KeyCallbackMap.find(key);
+			if (funcIter != Input::s_KeyCallbackMap.end())
 			{
 				funcIter->second();
 			}
@@ -28,7 +28,7 @@ namespace Walnut {
 
 	void Input::SetKeyCallback(KeyCode keycode, std::function<void()> func)
 	{
-		KEY_CALLBACK_MAP[(int)keycode] = func;
+		s_KeyCallbackMap[(int)keycode] = func;
 	}
 
 	bool Input::IsKeyDown(KeyCode keycode)

--- a/Walnut/src/Walnut/Input/Input.cpp
+++ b/Walnut/src/Walnut/Input/Input.cpp
@@ -10,7 +10,7 @@ namespace Walnut {
 
 	void KeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods)
 	{
-		if (action == GLFW_PRESS)
+		if (action == GLFW_PRESS || action == GLFW_REPEAT)
 		{
 			auto funcIter = Input::KEY_CALLBACK_MAP.find(key);
 			if (funcIter != Input::KEY_CALLBACK_MAP.end())
@@ -25,8 +25,6 @@ namespace Walnut {
 		GLFWwindow* windowHandle = Application::Get().GetWindowHandle();
 		glfwSetKeyCallback(windowHandle, KeyCallback);
 	}
-
-	
 
 	void Input::SetKeyCallback(KeyCode keycode, std::function<void()> func)
 	{

--- a/Walnut/src/Walnut/Input/Input.cpp
+++ b/Walnut/src/Walnut/Input/Input.cpp
@@ -13,6 +13,13 @@ namespace Walnut {
 		return state == GLFW_PRESS || state == GLFW_REPEAT;
 	}
 
+	bool Input::IsKeyPressed(KeyCode keycode)
+	{
+		GLFWwindow* windowHandle = Application::Get().GetWindowHandle();
+		int state = glfwGetKey(windowHandle, (int)keycode);
+		return state == GLFW_PRESS;
+	}
+
 	bool Input::IsMouseButtonDown(MouseButton button)
 	{
 		GLFWwindow* windowHandle = Application::Get().GetWindowHandle();

--- a/Walnut/src/Walnut/Input/Input.cpp
+++ b/Walnut/src/Walnut/Input/Input.cpp
@@ -6,27 +6,29 @@
 
 namespace Walnut {
 
-	void Input::InitKeysCallBack()
-	{
-		GLFWwindow* windowHandle = Application::Get().GetWindowHandle();
-		glfwSetKeyCallback(windowHandle, KeyCallback);
-	}
-
-	void Input::KeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods)
+	void KeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods)
 	{
 		if (action == GLFW_PRESS)
 		{
 			KeyCode keycode = (KeyCode)key;
 
-			auto funcIter = KEY_CALLBACK_MAP.find(keycode);
-			if (funcIter != KEY_CALLBACK_MAP.end())
+			auto funcIter = Input::KEY_CALLBACK_MAP.find(keycode);
+			if (funcIter != Input::KEY_CALLBACK_MAP.end())
 			{
 				funcIter->second();
 			}
 		}
 	}
 
-	void Input::SetKeyCallback(KeyCode keycode, std::function<void()>& func)
+	void Input::InitKeysCallBack()
+	{
+		GLFWwindow* windowHandle = Application::Get().GetWindowHandle();
+		glfwSetKeyCallback(windowHandle, KeyCallback);
+	}
+
+	
+
+	void Input::SetKeyCallback(KeyCode keycode, std::function<void()> func)
 	{
 		KEY_CALLBACK_MAP[keycode] = func;
 	}

--- a/Walnut/src/Walnut/Input/Input.h
+++ b/Walnut/src/Walnut/Input/Input.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "KeyCodes.h"
-
+#include <unordered_map>
+#include <string>
+#include <functional>
 #include <glm/glm.hpp>
 
 namespace Walnut {
@@ -9,13 +11,21 @@ namespace Walnut {
 	class Input
 	{
 	public:
+		static void InitKeysCallBack();
+
+		static void SetKeyCallback(KeyCode keycode, std::function<void()>& func);
+
 		static bool IsKeyDown(KeyCode keycode);
-		static bool IsKeyPressed(KeyCode keycode);
+
 		static bool IsMouseButtonDown(MouseButton button);
 
 		static glm::vec2 GetMousePosition();
 
 		static void SetCursorMode(CursorMode mode);
+
+		static void KeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods);
+
+		static std::unordered_map<KeyCode, std::function<void()>> KEY_CALLBACK_MAP;
 	};
 
 }

--- a/Walnut/src/Walnut/Input/Input.h
+++ b/Walnut/src/Walnut/Input/Input.h
@@ -10,6 +10,7 @@ namespace Walnut {
 	{
 	public:
 		static bool IsKeyDown(KeyCode keycode);
+		static bool IsKeyPressed(KeyCode keycode);
 		static bool IsMouseButtonDown(MouseButton button);
 
 		static glm::vec2 GetMousePosition();

--- a/Walnut/src/Walnut/Input/Input.h
+++ b/Walnut/src/Walnut/Input/Input.h
@@ -13,7 +13,7 @@ namespace Walnut {
 	public:
 		static void InitKeysCallBack();
 
-		static void SetKeyCallback(KeyCode keycode, std::function<void()>& func);
+		static void SetKeyCallback(KeyCode keycode, std::function<void()> func);
 
 		static bool IsKeyDown(KeyCode keycode);
 
@@ -22,8 +22,6 @@ namespace Walnut {
 		static glm::vec2 GetMousePosition();
 
 		static void SetCursorMode(CursorMode mode);
-
-		static void KeyCallback(GLFWwindow* window, int key, int scancode, int action, int mods);
 
 		static std::unordered_map<KeyCode, std::function<void()>> KEY_CALLBACK_MAP;
 	};

--- a/Walnut/src/Walnut/Input/Input.h
+++ b/Walnut/src/Walnut/Input/Input.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "KeyCodes.h"
-#include <unordered_map>
-#include <string>
+
 #include <functional>
+#include <unordered_map>
 #include <glm/glm.hpp>
 
 namespace Walnut {

--- a/Walnut/src/Walnut/Input/Input.h
+++ b/Walnut/src/Walnut/Input/Input.h
@@ -23,7 +23,7 @@ namespace Walnut {
 
 		static void SetCursorMode(CursorMode mode);
 
-		static std::unordered_map<int, std::function<void()>> KEY_CALLBACK_MAP;
+		static std::unordered_map<int, std::function<void()>> s_KeyCallbackMap;
 	};
 
 }

--- a/Walnut/src/Walnut/Input/Input.h
+++ b/Walnut/src/Walnut/Input/Input.h
@@ -23,7 +23,7 @@ namespace Walnut {
 
 		static void SetCursorMode(CursorMode mode);
 
-		static std::unordered_map<KeyCode, std::function<void()>> KEY_CALLBACK_MAP;
+		static std::unordered_map<int, std::function<void()>> KEY_CALLBACK_MAP;
 	};
 
 }


### PR DESCRIPTION
Existing Input class only checks for IsKeyDown, which checks the key state via glfwGetKey. This doesn't support keyboard's keypress delay and repeat events ASAP.

This PR adds support for custom key press callbacks, so that we can have a callback for every event emitted for a key press, and repeats follows the user's keyboard settings.

Reference for callbacks
https://www.glfw.org/docs/3.3/input_guide.html#input_key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced functionality for setting up and handling key callbacks, enhancing user interaction with keyboard events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->