### PR TITLE
Add ButtonLeft method

### DIFF
--- a/Walnut/Platform/GUI/Walnut/UI/UI.cpp
+++ b/Walnut/Platform/GUI/Walnut/UI/UI.cpp
@@ -552,6 +552,20 @@ namespace Walnut::UI {
 		return ImGui::Button(label);
 	}
 
+	bool ButtonLeft(const char* label, const ImVec2& size)
+	{
+		ImGuiStyle& style = ImGui::GetStyle();
+
+		float actualSize = ImGui::CalcTextSize(label).x + style.FramePadding.x * 2.0f;
+		float avail = ImGui::GetContentRegionAvail().x;
+
+		float off = (avail - actualSize);
+		if (off > 0.0f)
+			ImGui::SetCursorPosX(ImGui::GetCursorPosX() + off);
+
+		return ImGui::Button(label);
+	}
+
 	void DrawBorder(ImRect rect, float thickness, float rounding, float offsetX, float offsetY)
 	{
 		auto min = rect.Min;

--- a/Walnut/Platform/GUI/Walnut/UI/UI.h
+++ b/Walnut/Platform/GUI/Walnut/UI/UI.h
@@ -49,6 +49,7 @@ namespace Walnut::UI {
 	void EndMenubar();
 
 	bool ButtonCentered(const char* label, const ImVec2& size = ImVec2(0, 0));
+	bool ButtonLeft(const char* label, const ImVec2& size = ImVec2(0, 0));
 
 	// Utilities
 	class ScopedStyle


### PR DESCRIPTION
## Summary
Add a new method in the Walnut::UI namespace (UI.h/UI.cpp). This is a slightly modified version of ButtonCentered that creates left-aligned buttons. It can be useful for popups or other menus where alignment matters.

## Motivation
I originally Added this function because I was creating an application with a popup that required to have a "create" and a "cancel" button. I wanted them to be aligned on the right side for the "create"  button and left side for the "cancel". After some tweaking in the ButtonCentered method, I found out that changing the offset coefficient (0.5f to 1.0f) made the button aligned to the left (0.0f would be right). As multiplying by 1.0f can be ignored, I just removed the coefficient and arrived to the following method:

## Implementation (UI.cpp)
```cpp
bool ButtonLeft(const char* label, const ImVec2& size)
	{
		ImGuiStyle& style = ImGui::GetStyle();

		float actualSize = ImGui::CalcTextSize(label).x + style.FramePadding.x * 2.0f;
		float avail = ImGui::GetContentRegionAvail().x;

		float off = (avail - actualSize); // No coefficient
		if (off > 0.0f)
			ImGui::SetCursorPosX(ImGui::GetCursorPosX() + off);

		return ImGui::Button(label);
	}
```

## Use Case
```cpp
ImGui::Button("I'm to the right"); // Aligns to the right
Walnut::UI::ButtonCentered("I'm centered"); // Centered
Walnut::UI::ButtonLeft("I'm to the left"); // Aligns to the left
```